### PR TITLE
refac: Restricting the heapfy range

### DIFF
--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -8,6 +8,10 @@ int Heap::getRightChildIndex(unsigned int index){
 	return 2 * index + 2;
 }
 
+int Heap::getParentIndex(unsigned int index){
+        return floor(index / 2);
+}
+
 void Heap::swapNodeValue(unsigned int firstNodeIndex, unsigned int secondNodeIndex){
 	int tempValue = m_pData[secondNodeIndex];
 	m_pData[secondNodeIndex] = m_pData[firstNodeIndex];
@@ -35,7 +39,7 @@ Heap::Heap(int *pData, unsigned int size) : m_pData(pData), m_size(size){
 }
 
 void Heap::heapify(){
-	for (unsigned int index = m_size - 1; index + 1 > 0; index--){
+	for (unsigned int index = getParentIndex(m_size - 1); index + 1 > 0; index--){
 		bool wasSwaped = false;
 		if(nodeHasALeftChild(index)) trySwapNodes(index, getLeftChildIndex(index), &wasSwaped);
 		if(nodeHasARightChild(index)) trySwapNodes(index, getRightChildIndex(index), &wasSwaped);

--- a/src/heap.h
+++ b/src/heap.h
@@ -1,6 +1,8 @@
 #ifndef HEAP_H
 #define HEAP_H
 
+#include <math.h>
+
 class Heap{
 private:
 	
@@ -11,6 +13,7 @@ private:
 
 	int getLeftChildIndex(unsigned int index);
 	int getRightChildIndex(unsigned int index);
+	int getParentIndex(unsigned int index);
 	void swapNodeValue(unsigned int firstNodeIndex, unsigned int secondNodeIndex);
 	bool nodeHasALeftChild(unsigned int index);
 	bool nodeHasARightChild(unsigned int index);


### PR DESCRIPTION
This improvement is to make the program run faster. Now, the heapfy
method starts checking the first node with child.