### PR TITLE
refac: Replacing the initial boolean value

### DIFF
--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -23,6 +23,7 @@ bool Heap::nodeHasARightChild(unsigned int index){
 }
 
 void Heap::trySwapNodes(unsigned int index, unsigned int childIndex, bool wasSwaped){
+	wasSwaped = false;
 	int childValue = m_pData[childIndex];
 	if(childValue > m_pData[index]){
 		swapNodeValue(childIndex, index);


### PR DESCRIPTION
The wasSwaped variable is passed by reference to the trySwapNodes
method. However, to avoid bugs, I decided to set this variable to false
before using it.