### PR TITLE
fix: Rolling back the last change

### DIFF
--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -23,7 +23,6 @@ bool Heap::nodeHasARightChild(unsigned int index){
 }
 
 void Heap::trySwapNodes(unsigned int index, unsigned int childIndex, bool wasSwaped){
-	wasSwaped = false;
 	int childValue = m_pData[childIndex];
 	if(childValue > m_pData[index]){
 		swapNodeValue(childIndex, index);


### PR DESCRIPTION
I made a mistake in the last commit and I'm fixing it now. This
wasSwaped flag is used when any node in the heap is swapped. So, it must
be defined only once before used by the heapify method. This commit only
undoes the last change.